### PR TITLE
add validate input query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "shopify-functions-wasm-testing-helpers",
       "version": "1.0.0",
       "license": "MIT",
+      "dependencies": {
+        "graphql": "^16.11.0"
+      },
       "devDependencies": {
         "eslint": "^8.57.0",
         "jest": "^29.7.0"
@@ -2209,6 +2212,15 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "bugs": {
     "url": "https://github.com/your-username/shopify-functions-wasm-testing-helpers/issues"
   },
-  "homepage": "https://github.com/your-username/shopify-functions-wasm-testing-helpers#readme"
+  "homepage": "https://github.com/your-username/shopify-functions-wasm-testing-helpers#readme",
+  "dependencies": {
+    "graphql": "^16.11.0"
+  }
 }

--- a/src/methods/validate-fixture.js
+++ b/src/methods/validate-fixture.js
@@ -1,6 +1,29 @@
+const { validate, parse, buildSchema } = require('graphql');
+const fs = require('fs').promises;
+
 /**
  * Validate a fixture to ensure it has the correct structure
  */
+
+/**
+ * Validate a GraphQL input query file against a schema file
+ * @param {string} queryPath - Path to the GraphQL query file
+ * @param {string} schemaPath - Path to the GraphQL schema file
+ * @returns {Promise<Array>} Promise resolving to array of validation errors
+ */
+async function validateInputQuery(queryPath, schemaPath) {
+  try {
+    const inputQueryString = await fs.readFile(queryPath, 'utf8');
+    const inputQueryAST = parse(inputQueryString);
+    const schemaString = await fs.readFile(schemaPath, 'utf8');
+    const schema = buildSchema(schemaString);
+    
+    const validationErrors = validate(schema, inputQueryAST);
+    return validationErrors;
+  } catch (error) {
+    return [{ message: `Failed to validate query: ${error.message}` }];
+  }
+}
 
 /**
  * Validate a fixture to ensure it has the correct structure
@@ -53,4 +76,7 @@ function validateFixture(fixture) {
   };
 }
 
-module.exports = validateFixture;
+module.exports = {
+  validateFixture,
+  validateInputQuery
+};

--- a/test/fixtures/invalid-query.graphql
+++ b/test/fixtures/invalid-query.graphql
@@ -1,0 +1,11 @@
+query Input {
+  cart {
+    lines {
+      quantity
+      nonExistentField
+    }
+    buyerIdentity {
+      email
+    }
+  }
+}

--- a/test/fixtures/test-query.graphql
+++ b/test/fixtures/test-query.graphql
@@ -1,0 +1,14 @@
+query Input {
+  cart {
+    lines {
+      quantity
+      merchandise {
+        id
+        title
+      }
+    }
+    buyerIdentity {
+      email
+    }
+  }
+}

--- a/test/fixtures/test-schema.graphql
+++ b/test/fixtures/test-schema.graphql
@@ -1,0 +1,27 @@
+schema {
+  query: Input
+}
+
+type Input {
+  cart: Cart
+}
+
+type Cart {
+  lines: [CartLine!]!
+  buyerIdentity: BuyerIdentity
+}
+
+type CartLine {
+  quantity: Int!
+  merchandise: ProductVariant
+}
+
+type ProductVariant {
+  id: ID!
+  title: String!
+}
+
+type BuyerIdentity {
+  email: String
+  phone: String
+}

--- a/test/validate-input-query.test.js
+++ b/test/validate-input-query.test.js
@@ -1,0 +1,44 @@
+const { validateInputQuery } = require('../src/methods/validate-fixture.js');
+
+describe('validateInputQuery', () => {
+  it('should validate a valid GraphQL query against schema', async () => {
+    const queryPath = './test/fixtures/test-query.graphql';
+    const schemaPath = './test/fixtures/test-schema.graphql';
+    
+    const errors = await validateInputQuery(queryPath, schemaPath);
+    
+    expect(errors).toEqual([]);
+  });
+
+  it('should return validation errors for invalid GraphQL query', async () => {
+    const queryPath = './test/fixtures/invalid-query.graphql';
+    const schemaPath = './test/fixtures/test-schema.graphql';
+    
+    const errors = await validateInputQuery(queryPath, schemaPath);
+    
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toHaveProperty('message');
+  });
+
+  it('should return errors for invalid query file path', async () => {
+    const queryPath = './nonexistent/query.graphql';
+    const schemaPath = './test/fixtures/test-schema.graphql';
+    
+    const errors = await validateInputQuery(queryPath, schemaPath);
+    
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toHaveProperty('message');
+    expect(errors[0].message).toContain('Failed to validate query');
+  });
+
+  it('should return errors for invalid schema file path', async () => {
+    const queryPath = './test/fixtures/test-query.graphql';
+    const schemaPath = './nonexistent/schema.graphql';
+    
+    const errors = await validateInputQuery(queryPath, schemaPath);
+    
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toHaveProperty('message');
+    expect(errors[0].message).toContain('Failed to validate query');
+  });
+});


### PR DESCRIPTION
  ✅ Completed: validateInputQuery Implementation

  Location: /src/methods/validate-fixture.js

  What's implemented:
  - Single validateInputQuery(queryPath, schemaPath) function that takes file paths
  - Internally handles file reading, GraphQL parsing, schema building, and validation
  - Returns array of validation errors (empty if valid)
  - Clean implementation without console logging

  Testing:
  - Complete Jest test suite in /test/validate-input-query.test.js
  - Self-contained test fixtures in /test/fixtures/:
    - test-schema.graphql - Simple cart/product schema
    - test-query.graphql - Valid query
    - invalid-query.graphql - Invalid query for error testing
  - 4 test cases covering valid queries, invalid queries, and file path errors
  - All tests passing

  Dependencies:
  - Added graphql package to project