### PR TITLE
split errors out

### DIFF
--- a/src/methods/validate-fixture-output.ts
+++ b/src/methods/validate-fixture-output.ts
@@ -1,4 +1,4 @@
-import { isNonNullType, coerceInputValue, isInputType, GraphQLSchema } from 'graphql';
+import { coerceInputValue, isInputType, GraphQLSchema } from "graphql";
 
 /**
  * Interface for output fixture validation result
@@ -12,12 +12,12 @@ export interface OutputValidationResult {
 
 /**
  * Validate output fixture by checking if it can be used as input to the corresponding mutation
- * 
+ *
  * This approach leverages the fact that function output fixtures are designed to be used
  * as input parameters to GraphQL mutations. We can validate them by:
  * 1. Finding the mutation field and its parameter type in the schema
  * 2. Using GraphQL's coerceInputValue() to validate the fixture data against the expected input type
- * 
+ *
  * @param {Object} outputFixtureData - The output fixture data to validate
  * @param {GraphQLSchema} originalSchema - The original GraphQL schema
  * @param {string} mutationName - The mutation field name (e.g., 'cartValidationsGenerateRun')
@@ -32,13 +32,13 @@ export async function validateFixtureOutput(
   outputFixtureData: Record<string, any>,
   originalSchema: GraphQLSchema,
   mutationName: string,
-  resultParameterName: string = 'result'
+  resultParameterName: string = "result"
 ): Promise<OutputValidationResult> {
   try {
     // Get the mutation type from schema
     const mutationType = originalSchema.getMutationType();
     if (!mutationType) {
-      throw new Error('Schema does not have a mutation type');
+      throw new Error("Schema does not have a mutation type");
     }
 
     // Get the specific mutation field
@@ -49,48 +49,43 @@ export async function validateFixtureOutput(
     }
 
     // Get the result parameter type
-    const resultArg = mutationField.args.find(arg => arg.name === resultParameterName);
+    const resultArg = mutationField.args.find(
+      (arg) => arg.name === resultParameterName
+    );
     if (!resultArg) {
-      throw new Error(`Parameter '${resultParameterName}' not found in mutation '${mutationName}'`);
+      throw new Error(
+        `Parameter '${resultParameterName}' not found in mutation '${mutationName}'`
+      );
     }
 
-    // Validate the fixture data directly against the parameter type
-    let errors: { message: string }[] = [];
-    try {
-      // Validate the result parameter value against its expected type
-      let inputType = resultArg.type;
-      
-      // Handle NonNull wrapper types
-      if (isNonNullType(inputType)) {
-        inputType = inputType.ofType;
-      }
-      
-      if (isInputType(inputType)) {
-        const coercionResult = coerceInputValue(outputFixtureData, resultArg.type);
-        if (coercionResult && typeof coercionResult === 'object' && 'errors' in coercionResult && Array.isArray(coercionResult.errors) && coercionResult.errors.length > 0) {
-          errors.push(...coercionResult.errors.map((err: any) => ({ message: err.message || String(err) })));
+    // Validate the fixture data using coerceInputValue with error collection
+    const errors: { message: string }[] = [];
+
+    if (isInputType(resultArg.type)) {
+      coerceInputValue(
+        outputFixtureData,
+        resultArg.type,
+        (path, _invalidValue, error) => {
+          errors.push({
+            message: `${error.message} At "${path.join(".")}"`,
+          });
         }
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      errors = [{ message: errorMessage }];
+      );
     }
 
     return {
       valid: errors.length === 0,
       errors: errors,
       mutationName: mutationName,
-      resultParameterType: resultArg.type.toString()
+      resultParameterType: resultArg.type.toString(),
     };
-
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     return {
       valid: false,
       errors: [{ message: errorMessage }],
       mutationName: mutationName,
-      resultParameterType: null
+      resultParameterType: null,
     };
   }
 }
-

--- a/test/methods/validate-fixture-output.test.ts
+++ b/test/methods/validate-fixture-output.test.ts
@@ -130,7 +130,9 @@ describe("validateFixtureOutput", () => {
 
       expect(result.valid).toBe(false);
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0].message).toBe("Invalid value \"this should be an array\" at \"value.operations\": Expected type \"DataOperation\" to be an object.");
+      expect(result.errors[0].message).toBe(
+        'Expected type "DataOperation" to be an object. At "operations"'
+      );
     });
 
     it("should detect extra fields in ValidationAddOperation", async () => {
@@ -164,12 +166,19 @@ describe("validateFixtureOutput", () => {
         "result"
       );
 
-      // Should detect the extra fields as invalid
+      // Should detect each extra field as a separate error
       expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
+      expect(result.errors).toHaveLength(3);
+
+      // Check each extra field gets its own specific error
       expect(result.errors[0].message).toBe(
-        'Invalid value { errors: [[Object]], extraField1: "this should not be allowed", extraField2: 123, nestedExtra: { invalidNested: "also invalid" } } ' +
-        'at "value.operations[0].addValidation": Field "extraField1" is not defined by type "AddValidationOperation".'
+        'Field "extraField1" is not defined by type "AddValidationOperation". At "operations.0.addValidation"'
+      );
+      expect(result.errors[1].message).toBe(
+        'Field "extraField2" is not defined by type "AddValidationOperation". At "operations.0.addValidation"'
+      );
+      expect(result.errors[2].message).toBe(
+        'Field "nestedExtra" is not defined by type "AddValidationOperation". At "operations.0.addValidation"'
       );
     });
   });


### PR DESCRIPTION
Improves errors from validate-output-fixture.
now splits them out properly into the errors array instead of piling it all into the first element.