### PR TITLE
remove test-app from dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "types": "dist/wasm-testing-helpers.d.ts",
   "type": "module",
   "files": [
-    "dist/",
-    "test-app/"
+    "dist/"
   ],
   "workspaces": [
     "test-app",


### PR DESCRIPTION
users of the package don't need the test-app, as that directory is just to help us with testing