### PR TITLE
add support for detecting extra fields in fixtures

### DIFF
--- a/test/methods/validate-test-assets.test.ts
+++ b/test/methods/validate-test-assets.test.ts
@@ -140,10 +140,11 @@ describe('validateTestAssets', () => {
 
       expect(result.inputQuery.errors).toHaveLength(0);
 
-      // Input fixture should be invalid due to missing fields
-      expect(result.inputFixture.errors.length).toBe(2);
+      // Input fixture should be invalid due to missing fields and extra field
+      expect(result.inputFixture.errors.length).toBe(3);
       expect(result.inputFixture.errors[0]).toBe('Missing expected fixture data for details');
-      expect(result.inputFixture.errors[1]).toBe('Missing expected fixture data for metadata');
+      expect(result.inputFixture.errors[1]).toBe('Extra field "invalidField" found in fixture data not in query');
+      expect(result.inputFixture.errors[2]).toBe('Missing expected fixture data for metadata');
 
       expect(result.outputFixture.errors).toHaveLength(0);
     });


### PR DESCRIPTION
Detects extra fields by keeping track of expectedFields (aka the ones we've visited) in a new stack, parallel to the existing valueStack. Then when leaving a node with a selection set, compare what's available in the fixture to the visited field names to find extras.