### PR TITLE
changeset to release extra-fields validation

### DIFF
--- a/.changeset/twelve-bobcats-write.md
+++ b/.changeset/twelve-bobcats-write.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-function-test-helpers": patch
+---
+
+Add validation for extra fixtures


### PR DESCRIPTION
Missed adding the changeset directly to my [extra fields validation PR](https://github.com/Shopify/shopify-function-test-helpers/pull/33), so I'm adding it now.

Once this merges it will kick off another of these [Version Changesets PR](https://github.com/Shopify/shopify-function-test-helpers/pull/37), which we can merge to push the feature (and version 0.0.3) to the registry.