### PR TITLE
Consistent field name formatting in error messages

### DIFF
--- a/src/methods/validate-fixture-input.ts
+++ b/src/methods/validate-fixture-input.ts
@@ -121,7 +121,7 @@ export function validateFixtureInput(
           if (fieldDefinition === undefined || fieldDefinition === null) {
             const currentPath = pathFromAncestors(ancestors);
             errors.push({
-              message: `Cannot validate ${responseKey}: missing field definition`,
+              message: `Cannot validate \`${responseKey}\`: missing field definition`,
               path: [...currentPath, responseKey],
             });
             return BREAK;
@@ -151,7 +151,7 @@ export function validateFixtureInput(
                 )
               ) {
                 errors.push({
-                  message: `Missing expected fixture data for ${responseKey}`,
+                  message: `Missing expected fixture data for \`${responseKey}\``,
                   path: [...currentPath, responseKey],
                 });
               }
@@ -227,7 +227,7 @@ export function validateFixtureInput(
               // Unexpected type - defensive check that should never be reached
               else {
                 errors.push({
-                  message: `Unexpected type, expected ${unwrappedFieldType}`,
+                  message: `Unexpected type, expected \`${unwrappedFieldType}\``,
                   path: [...currentPath, responseKey],
                 });
               }
@@ -235,7 +235,7 @@ export function validateFixtureInput(
             // No type information - should not happen with valid query
             else {
               errors.push({
-                message: `Cannot validate ${responseKey}: missing type information`,
+                message: `Cannot validate \`${responseKey}\`: missing type information`,
                 path: [...currentPath, responseKey],
               });
             }
@@ -313,7 +313,7 @@ export function validateFixtureInput(
             if (!hasTypename && fragmentSpreadCount > 1) {
               const currentPath = pathFromAncestors([...ancestors, parent!]);
               errors.push({
-                message: `Missing __typename field for abstract type ${getNamedType(typeInfo.getType())?.name}`,
+                message: `Missing \`__typename\` field for abstract type \`${getNamedType(typeInfo.getType())?.name}\``,
                 path: currentPath,
               });
               return BREAK;
@@ -536,7 +536,7 @@ function checkForExtraFields(
       for (const fixtureField of fixtureFields) {
         if (!expectedForThisObject.has(fixtureField)) {
           errors.push({
-            message: `Extra field "${fixtureField}" found in fixture data not in query`,
+            message: `Extra field \`${fixtureField}\` found in fixture data not in query`,
             path: [...path, fixtureField],
           });
         }

--- a/test/methods/validate-fixture-input.test.ts
+++ b/test/methods/validate-fixture-input.test.ts
@@ -255,7 +255,7 @@ describe("validateFixtureInput", () => {
       // - Detects missing __typename and BREAKs early
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing __typename field for abstract type NestedInner",
+        message: "Missing `__typename` field for abstract type `NestedInner`",
         path: ["data", "nested", "inner"],
       });
     });
@@ -648,15 +648,15 @@ describe("validateFixtureInput", () => {
       // So it conservatively expects all selected fields on non-empty objects
       expect(result.errors).toHaveLength(3);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for name",
+        message: "Missing expected fixture data for `name`",
         path: ["data", "interfaceImplementers", 2, "name"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: "Missing expected fixture data for description",
+        message: "Missing expected fixture data for `description`",
         path: ["data", "interfaceImplementers", 1, "description"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: "Missing expected fixture data for description",
+        message: "Missing expected fixture data for `description`",
         path: ["data", "interfaceImplementers", 2, "description"],
       });
     });
@@ -1230,15 +1230,15 @@ describe("validateFixtureInput", () => {
       const result = validateFixtureInput(queryAST, schema, fixtureInput);
       expect(result.errors).toHaveLength(3);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for count",
+        message: "Missing expected fixture data for `count`",
         path: ["data", "items", 0, "count"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: "Missing expected fixture data for details",
+        message: "Missing expected fixture data for `details`",
         path: ["data", "items", 0, "details"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: "Missing expected fixture data for metadata",
+        message: "Missing expected fixture data for `metadata`",
         path: ["data", "metadata"],
       });
     });
@@ -1270,7 +1270,7 @@ describe("validateFixtureInput", () => {
       // Should detect that 'count' is not in the query
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "count" found in fixture data not in query',
+        message: "Extra field `count` found in fixture data not in query",
         path: ["data", "items", 0, "count"],
       });
     });
@@ -1321,11 +1321,11 @@ describe("validateFixtureInput", () => {
       // Each alias is validated independently, so extra fields in each should be detected
       expect(result.errors).toHaveLength(2);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "details" found in fixture data not in query',
+        message: "Extra field `details` found in fixture data not in query",
         path: ["data", "firstItems", 0, "details"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "count" found in fixture data not in query',
+        message: "Extra field `count` found in fixture data not in query",
         path: ["data", "secondItems", 0, "count"],
       });
     });
@@ -1357,7 +1357,7 @@ describe("validateFixtureInput", () => {
       // Should detect the version field since it wasn't selected in the query
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "version" found in fixture data not in query',
+        message: "Extra field `version` found in fixture data not in query",
         path: ["version"],
       });
     });
@@ -1485,40 +1485,40 @@ describe("validateFixtureInput", () => {
       expect(result.errors).toHaveLength(9);
       expect(result.errors[0]).toStrictEqual({
         message:
-          'Extra field "extraDetailField" found in fixture data not in query',
+          "Extra field `extraDetailField` found in fixture data not in query",
         path: ["data", "searchResults", 0, "details", "extraDetailField"],
       }); // details (deepest)
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "count" found in fixture data not in query',
+        message: "Extra field `count` found in fixture data not in query",
         path: ["data", "searchResults", 0, "count"],
       }); // Item
       expect(result.errors[2]).toStrictEqual({
-        message: 'Extra field "phone" found in fixture data not in query',
+        message: "Extra field `phone` found in fixture data not in query",
         path: ["data", "searchResults", 1, "phone"],
       }); // Metadata
       expect(result.errors[3]).toStrictEqual({
-        message: 'Extra field "description" found in fixture data not in query',
+        message: "Extra field `description` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 0, "description"],
       }); // InterfaceImplementer1
       expect(result.errors[4]).toStrictEqual({
-        message: 'Extra field "extraField" found in fixture data not in query',
+        message: "Extra field `extraField` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 1, "extraField"],
       }); // InterfaceImplementer2
       expect(result.errors[5]).toStrictEqual({
-        message: 'Extra field "value" found in fixture data not in query',
+        message: "Extra field `value` found in fixture data not in query",
         path: ["data", "nested", 0, "inner", 0, "value"],
       }); // NestedInnerA cross-contamination
       expect(result.errors[6]).toStrictEqual({
-        message: 'Extra field "email" found in fixture data not in query',
+        message: "Extra field `email` found in fixture data not in query",
         path: ["data", "nested", 0, "email"],
       }); // NestedOuterA cross-contamination
       expect(result.errors[7]).toStrictEqual({
-        message: 'Extra field "id" found in fixture data not in query',
+        message: "Extra field `id` found in fixture data not in query",
         path: ["data", "nested", 1, "id"],
       }); // NestedOuterB cross-contamination
       expect(result.errors[8]).toStrictEqual({
         message:
-          'Extra field "extraRootField" found in fixture data not in query',
+          "Extra field `extraRootField` found in fixture data not in query",
         path: ["extraRootField"],
       }); // root (last)
     });
@@ -1562,11 +1562,11 @@ describe("validateFixtureInput", () => {
       // Should detect extra fields in both union members
       expect(result.errors).toHaveLength(2);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "count" found in fixture data not in query',
+        message: "Extra field `count` found in fixture data not in query",
         path: ["data", "searchResults", 0, "count"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "phone" found in fixture data not in query',
+        message: "Extra field `phone` found in fixture data not in query",
         path: ["data", "searchResults", 1, "phone"],
       });
     });
@@ -1618,19 +1618,19 @@ describe("validateFixtureInput", () => {
       // Metadata should NOT have id/count (those are Item fields)
       expect(result.errors).toHaveLength(4);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "email" found in fixture data not in query',
+        message: "Extra field `email` found in fixture data not in query",
         path: ["data", "searchResults", 0, "email"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "phone" found in fixture data not in query',
+        message: "Extra field `phone` found in fixture data not in query",
         path: ["data", "searchResults", 0, "phone"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: 'Extra field "id" found in fixture data not in query',
+        message: "Extra field `id` found in fixture data not in query",
         path: ["data", "searchResults", 1, "id"],
       });
       expect(result.errors[3]).toStrictEqual({
-        message: 'Extra field "count" found in fixture data not in query',
+        message: "Extra field `count` found in fixture data not in query",
         path: ["data", "searchResults", 1, "count"],
       });
     });
@@ -1691,27 +1691,27 @@ describe("validateFixtureInput", () => {
       // - name, description, and extraField3 on InterfaceImplementer3 (doesn't implement HasName or HasDescription)
       expect(result.errors).toHaveLength(6);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "extraField1" found in fixture data not in query',
+        message: "Extra field `extraField1` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 0, "extraField1"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "description" found in fixture data not in query',
+        message: "Extra field `description` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 1, "description"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: 'Extra field "extraField2" found in fixture data not in query',
+        message: "Extra field `extraField2` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 1, "extraField2"],
       });
       expect(result.errors[3]).toStrictEqual({
-        message: 'Extra field "name" found in fixture data not in query',
+        message: "Extra field `name` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 2, "name"],
       });
       expect(result.errors[4]).toStrictEqual({
-        message: 'Extra field "description" found in fixture data not in query',
+        message: "Extra field `description` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 2, "description"],
       });
       expect(result.errors[5]).toStrictEqual({
-        message: 'Extra field "extraField3" found in fixture data not in query',
+        message: "Extra field `extraField3` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 2, "extraField3"],
       });
     });
@@ -1774,15 +1774,15 @@ describe("validateFixtureInput", () => {
       // - id on NestedOuterB (outer level)
       expect(result.errors).toHaveLength(3);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "value" found in fixture data not in query',
+        message: "Extra field `value` found in fixture data not in query",
         path: ["data", "nested", 0, "inner", 0, "value"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "email" found in fixture data not in query',
+        message: "Extra field `email` found in fixture data not in query",
         path: ["data", "nested", 0, "email"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: 'Extra field "id" found in fixture data not in query',
+        message: "Extra field `id` found in fixture data not in query",
         path: ["data", "nested", 1, "id"],
       });
     });
@@ -1842,27 +1842,27 @@ describe("validateFixtureInput", () => {
       // - name and description on InterfaceImplementer3 (only id queried)
       expect(result.errors).toHaveLength(6);
       expect(result.errors[0]).toStrictEqual({
-        message: 'Extra field "description" found in fixture data not in query',
+        message: "Extra field `description` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 0, "description"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: 'Extra field "extraField1" found in fixture data not in query',
+        message: "Extra field `extraField1` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 0, "extraField1"],
       });
       expect(result.errors[2]).toStrictEqual({
-        message: 'Extra field "name" found in fixture data not in query',
+        message: "Extra field `name` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 1, "name"],
       });
       expect(result.errors[3]).toStrictEqual({
-        message: 'Extra field "extraField2" found in fixture data not in query',
+        message: "Extra field `extraField2` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 1, "extraField2"],
       });
       expect(result.errors[4]).toStrictEqual({
-        message: 'Extra field "name" found in fixture data not in query',
+        message: "Extra field `name` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 2, "name"],
       });
       expect(result.errors[5]).toStrictEqual({
-        message: 'Extra field "description" found in fixture data not in query',
+        message: "Extra field `description` found in fixture data not in query",
         path: ["data", "interfaceImplementers", 2, "description"],
       });
     });
@@ -1958,7 +1958,7 @@ describe("validateFixtureInput", () => {
       const result = validateFixtureInput(queryAST, schema, fixtureInput);
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for metadata",
+        message: "Missing expected fixture data for `metadata`",
         path: ["data", "metadata"],
       });
     });
@@ -2059,7 +2059,7 @@ describe("validateFixtureInput", () => {
       // Should detect missing type information for the invalid field
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Cannot validate nonExistentField: missing field definition",
+        message: "Cannot validate `nonExistentField`: missing field definition",
         path: ["data", "items", "nonExistentField"],
       });
     });
@@ -2093,11 +2093,11 @@ describe("validateFixtureInput", () => {
       // Empty object {} is invalid in non-union context - missing required fields
       expect(result.errors).toHaveLength(2);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for id",
+        message: "Missing expected fixture data for `id`",
         path: ["data", "items", 1, "id"],
       });
       expect(result.errors[1]).toStrictEqual({
-        message: "Missing expected fixture data for count",
+        message: "Missing expected fixture data for `count`",
         path: ["data", "items", 1, "count"],
       });
     });
@@ -2127,7 +2127,7 @@ describe("validateFixtureInput", () => {
       // We're not discriminating between union members, so all fields are required
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for price",
+        message: "Missing expected fixture data for `price`",
         path: ["data", "purchasable", "price"],
       });
     });
@@ -2166,7 +2166,7 @@ describe("validateFixtureInput", () => {
       // However, NO cascading field errors because all fragments select on same type
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing __typename field for abstract type SearchResult",
+        message: "Missing `__typename` field for abstract type `SearchResult`",
         path: ["data", "searchResults"],
       });
     });
@@ -2210,7 +2210,7 @@ describe("validateFixtureInput", () => {
       // Validator detects missing __typename for abstract type with 2+ fragments and BREAKs early
       expect(result.errors).toHaveLength(1);
       expect(result.errors[0]).toStrictEqual({
-        message: "Missing __typename field for abstract type SearchResult",
+        message: "Missing `__typename` field for abstract type `SearchResult`",
         path: ["data", "searchResults"],
       });
     });

--- a/test/methods/validate-test-assets.test.ts
+++ b/test/methods/validate-test-assets.test.ts
@@ -124,11 +124,11 @@ describe("validateTestAssets", () => {
         path: ["data", "items", 0, "count"],
       });
       expect(result.inputFixture.errors[1]).toStrictEqual({
-        message: "Missing expected fixture data for details",
+        message: "Missing expected fixture data for `details`",
         path: ["data", "items", 0, "details"],
       });
       expect(result.inputFixture.errors[2]).toStrictEqual({
-        message: "Missing expected fixture data for metadata",
+        message: "Missing expected fixture data for `metadata`",
         path: ["data", "metadata"],
       });
     });
@@ -163,16 +163,16 @@ describe("validateTestAssets", () => {
       // Input fixture should be invalid due to missing fields and extra field
       expect(result.inputFixture.errors.length).toBe(3);
       expect(result.inputFixture.errors[0]).toStrictEqual({
-        message: "Missing expected fixture data for details",
+        message: "Missing expected fixture data for `details`",
         path: ["data", "items", 0, "details"],
       });
       expect(result.inputFixture.errors[1]).toStrictEqual({
         message:
-          'Extra field "invalidField" found in fixture data not in query',
+          "Extra field `invalidField` found in fixture data not in query",
         path: ["data", "items", 0, "invalidField"],
       });
       expect(result.inputFixture.errors[2]).toStrictEqual({
-        message: "Missing expected fixture data for metadata",
+        message: "Missing expected fixture data for `metadata`",
         path: ["data", "metadata"],
       });
 


### PR DESCRIPTION
Use backticks around all field names in error messages for fixture input validation