### PR TITLE
use new oidc config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,14 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
 env:
-  NODE_VERSION: '20.x'
-  PNPM_VERSION: '10.20.0'
+  NODE_VERSION: "22.14.0"
+  PNPM_VERSION: "10.20.0"
 
 jobs:
   release:
@@ -23,6 +28,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm to latest
+        run: npm install -g npm@latest
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -53,4 +62,4 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ""


### PR DESCRIPTION
updates the release flow to match the updated docs, including intentionally setting the NPM_TOKEN to an empty string.